### PR TITLE
Fix iconv crash

### DIFF
--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -61,4 +61,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && rm installer \
     && apk del -f .build-deps
 
+# Fix for iconv: https://github.com/docker-library/php/issues/240
+ENV LD_PRELOAD /usr/lib/preloadable_libiconv.so php
+
 WORKDIR /var/www


### PR DESCRIPTION
Apparently the second part of fix was not carried from the 7.3 dockerfile.